### PR TITLE
feat: harden getJsonPathForPosition

### DIFF
--- a/src/__tests__/fixtures/demo.yaml
+++ b/src/__tests__/fixtures/demo.yaml
@@ -218,8 +218,8 @@ austrian-cities: &austrian-cities
 
 cities:
   europe:
-    <<: *german-cities
-    <<: *austrian-cities
+    - *german-cities
+    - *austrian-cities
     - Rome
     - Paris
     - London
@@ -230,3 +230,8 @@ cities:
     - Shanghai
     - Shenzen
     - Macau
+
+european-cities:
+  germany: *german-cities
+
+  austria: *austrian-cities

--- a/src/__tests__/fixtures/demo.yaml
+++ b/src/__tests__/fixtures/demo.yaml
@@ -1,0 +1,232 @@
+---
+# Collection Types #############################################################
+################################################################################
+
+# http://yaml.org/type/map.html -----------------------------------------------#
+
+map:
+  # Unordered set of key: value pairs.
+  Block style: !!map
+    Clark : Evans
+    Ingy  : döt Net
+    Oren  : Ben-Kiki
+  Flow style: !!map { Clark: Evans, Ingy: döt Net, Oren: Ben-Kiki }
+
+# http://yaml.org/type/omap.html ----------------------------------------------#
+
+omap:
+  # Explicitly typed ordered map (dictionary).
+  Bestiary: !!omap
+    - aardvark: African pig-like ant eater. Ugly.
+    - anteater: South-American ant eater. Two species.
+    - anaconda: South-American constrictor snake. Scaly.
+    # Etc.
+  # Flow style
+  Numbers: !!omap [ one: 1, two: 2, three : 3 ]
+
+# http://yaml.org/type/pairs.html ---------------------------------------------#
+
+pairs:
+  # Explicitly typed pairs.
+  Block tasks: !!pairs
+    - meeting: with team.
+    - meeting: with boss.
+    - break: lunch.
+    - meeting: with client.
+  Flow tasks: !!pairs [ meeting: with team, meeting: with boss ]
+
+# http://yaml.org/type/set.html -----------------------------------------------#
+
+set:
+  # Explicitly typed set.
+  baseball players: !!set
+    ? Mark McGwire
+    ? Sammy Sosa
+    ? Ken Griffey
+      # Flow style
+  baseball teams: !!set { Boston Red Sox, Detroit Tigers, New York Yankees }
+
+# http://yaml.org/type/seq.html -----------------------------------------------#
+
+seq:
+  # Ordered sequence of nodes
+  Block style: !!seq
+    - Mercury   # Rotates - no light/dark sides.
+    - Venus     # Deadliest. Aptly named.
+    - Earth     # Mostly dirt.
+    - Mars      # Seems empty.
+    - Jupiter   # The king.
+    - Saturn    # Pretty.
+    - Uranus    # Where the sun hardly shines.
+    - Neptune   # Boring. No rings.
+    - Pluto     # You call this a planet?
+  Flow style: !!seq [ Mercury, Venus, Earth, Mars,      # Rocks
+                      Jupiter, Saturn, Uranus, Neptune, # Gas
+                      Pluto ]                           # Overrated
+
+
+# Scalar Types #################################################################
+################################################################################
+
+# http://yaml.org/type/bool.html ----------------------------------------------#
+
+bool:
+  - true
+  - True
+  - TRUE
+  - false
+  - False
+  - FALSE
+
+# http://yaml.org/type/float.html ---------------------------------------------#
+
+float:
+  canonical: 6.8523015e+5
+  exponentioal: 685.230_15e+03
+  fixed: 685_230.15
+  sexagesimal: 190:20:30.15
+  negative infinity: -.inf
+  not a number: .NaN
+
+# http://yaml.org/type/int.html -----------------------------------------------#
+
+int:
+  canonical: 685230
+  decimal: +685_230
+  octal: 02472256
+  hexadecimal: 0x_0A_74_AE
+  binary: 0b1010_0111_0100_1010_1110
+  sexagesimal: 190:20:30
+
+# http://yaml.org/type/merge.html ---------------------------------------------#
+
+merge:
+  - &CENTER { x: 1, y: 2 }
+  - &LEFT { x: 0, y: 2 }
+  - &BIG { r: 10 }
+  - &SMALL { r: 1 }
+
+  # All the following maps are equal:
+
+  - # Explicit keys
+    x: 1
+    y: 2
+    r: 10
+    label: nothing
+
+  - # Merge one map
+    << : *CENTER
+    r: 10
+    label: center
+
+  - # Merge multiple maps
+    << : [ *CENTER, *BIG ]
+    label: center/big
+
+  - # Override
+    << : [ *BIG, *LEFT, *SMALL ]
+    x: 1
+    label: big/left/small
+
+# http://yaml.org/type/null.html ----------------------------------------------#
+
+null:
+  # This mapping has four keys,
+  # one has a value.
+  empty:
+  canonical: ~
+  english: null
+  ~: null key
+  # This sequence has five
+  # entries, two have values.
+  sparse:
+    - ~
+    - 2nd entry
+    -
+    - 4th entry
+    - Null
+
+# http://yaml.org/type/str.html -----------------------------------------------#
+
+string: abcd
+
+# http://yaml.org/type/timestamp.html -----------------------------------------#
+
+timestamp:
+  canonical:        2001-12-15T02:59:43.1Z
+  valid iso8601:    2001-12-14t21:59:43.10-05:00
+  space separated:  2001-12-14 21:59:43.10 -5
+  no time zone (Z): 2001-12-15 2:59:43.10
+  date (00:00:00Z): 2002-12-14
+
+
+# JavaScript Specific Types ####################################################
+################################################################################
+
+# https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/RegExp
+
+regexp:
+  simple: !!js/regexp      foobar
+  modifiers: !!js/regexp   /foobar/mi
+
+# https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/undefined
+
+undefined: !!js/undefined ~
+
+# https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function
+
+function: !!js/function >
+  function foobar() {
+    return 'Wow! JS-YAML Rocks!';
+  }
+
+
+# Custom types #################################################################
+################################################################################
+
+
+# JS-YAML allows you to specify a custom YAML types for your structures.
+# This is a simple example of custom constructor defined in `js/demo.js` for
+# custom `!sexy` type:
+#
+# var SexyYamlType = new jsyaml.Type('!sexy', {
+#   kind: 'sequence',
+#   construct: function (data) {
+#     return data.map(function (string) { return 'sexy ' + string; });
+#   }
+# });
+#
+# var SEXY_SCHEMA = jsyaml.Schema.create([ SexyYamlType ]);
+#
+# result = jsyaml.load(yourData, { schema: SEXY_SCHEMA });
+
+foobar: !sexy
+  - bunny
+  - chocolate
+
+german-cities: &german-cities
+  - Munich
+  - Frankfurt
+  - Berlin
+  - Hamburg
+
+austrian-cities: &austrian-cities
+  - Vienna
+  - Graz
+  - Linz
+  - Salzburg
+
+cities:
+  europe:
+    <<: *german-cities
+    <<: *austrian-cities
+    - Rome
+    - Paris
+    - London
+  asia:
+    - Hanoi
+    - Beijing
+    - Bangkok
+    - Shanghai
+    - Shenzen
+    - Macau

--- a/src/__tests__/getJsonPathForPosition.spec.ts
+++ b/src/__tests__/getJsonPathForPosition.spec.ts
@@ -8,6 +8,14 @@ const simple = `hello: world
 address:
   street: 123`;
 
+const inline = `map:
+  # Unordered set of key: value pairs.
+  Block style: !!map
+    Clark : Evans
+    Ingy  : döt Net
+    Oren  : Ben-Kiki
+  Flow style: !!map { Clark: Evans, Ingy: döt Net, Oren: Ben-Kiki }`;
+
 describe('getJsonPathForPosition', () => {
   describe('simple fixture', () => {
     const result = parseWithPointers(simple);
@@ -18,8 +26,28 @@ describe('getJsonPathForPosition', () => {
       ${0} | ${13}     | ${undefined}
       ${0} | ${4}      | ${['hello']}
       ${1} | ${0}      | ${['address']}
+      ${1} | ${7}      | ${['address']}
       ${1} | ${12}     | ${['address']}
       ${2} | ${4}      | ${['address', 'street']}
+    `('should return proper json path for line $line and character $character', ({ line, character, path }) => {
+      expect(getJsonPathForPosition(result, { line, character })).toEqual(path);
+    });
+  });
+
+  describe('inline fixture', () => {
+    const result = parseWithPointers(inline);
+
+    test.each`
+      line | character | path
+      ${1} | ${0}      | ${['map', 'Block style']}
+      ${6} | ${0}      | ${['map', 'Flow style']}
+      ${6} | ${4}      | ${['map', 'Flow style']}
+      ${6} | ${25}     | ${['map', 'Flow style', 'Clark']}
+      ${6} | ${34}     | ${['map', 'Flow style', 'Clark']}
+      ${6} | ${38}     | ${['map', 'Flow style', 'Ingy']}
+      ${6} | ${51}     | ${['map', 'Flow style', 'Oren']}
+      ${6} | ${52}     | ${['map', 'Flow style', 'Oren']}
+      ${6} | ${57}     | ${['map', 'Flow style', 'Oren']}
     `('should return proper json path for line $line and character $character', ({ line, character, path }) => {
       expect(getJsonPathForPosition(result, { line, character })).toEqual(path);
     });
@@ -36,8 +64,13 @@ describe('getJsonPathForPosition', () => {
       ${2}  | ${0}      | ${['info', 'title']}
       ${2}  | ${3}      | ${['info', 'title']}
       ${2}  | ${5}      | ${['info', 'title']}
+      ${2}  | ${12}     | ${['info', 'title']}
       ${3}  | ${7}      | ${['info', 'version']}
+      ${4}  | ${0}      | ${['info', 'description']}
+      ${6}  | ${3}      | ${['info', 'description']}
+      ${7}  | ${0}      | ${['info', 'description']}
       ${18} | ${25}     | ${['tags', 0, 'description']}
+      ${27} | ${18}     | ${['tags', 2, 'externalDocs', 'description']}
       ${30} | ${7}      | ${['schemes', 0]}
       ${31} | ${5}      | ${['schemes', 1]}
       ${40} | ${0}      | ${['paths', '/pets', 'post', 'consumes']}

--- a/src/__tests__/getJsonPathForPosition.spec.ts
+++ b/src/__tests__/getJsonPathForPosition.spec.ts
@@ -4,17 +4,10 @@ import { getJsonPathForPosition } from '../getJsonPathForPosition';
 import { parseWithPointers } from '../parseWithPointers';
 
 const petStore = fs.readFileSync(join(__dirname, './fixtures/petstore.oas2.yaml'), 'utf-8');
+const demo = fs.readFileSync(join(__dirname, './fixtures/demo.yaml'), 'utf-8');
 const simple = `hello: world
 address:
   street: 123`;
-
-const inline = `map:
-  # Unordered set of key: value pairs.
-  Block style: !!map
-    Clark : Evans
-    Ingy  : döt Net
-    Oren  : Ben-Kiki
-  Flow style: !!map { Clark: Evans, Ingy: döt Net, Oren: Ben-Kiki }`;
 
 describe('getJsonPathForPosition', () => {
   describe('simple fixture', () => {
@@ -34,20 +27,48 @@ describe('getJsonPathForPosition', () => {
     });
   });
 
-  describe('inline fixture', () => {
-    const result = parseWithPointers(inline);
+  describe('demo fixture', () => {
+    const result = parseWithPointers(demo);
 
     test.each`
-      line | character | path
-      ${1} | ${0}      | ${['map', 'Block style']}
-      ${6} | ${0}      | ${['map', 'Flow style']}
-      ${6} | ${4}      | ${['map', 'Flow style']}
-      ${6} | ${25}     | ${['map', 'Flow style', 'Clark']}
-      ${6} | ${34}     | ${['map', 'Flow style', 'Clark']}
-      ${6} | ${38}     | ${['map', 'Flow style', 'Ingy']}
-      ${6} | ${51}     | ${['map', 'Flow style', 'Oren']}
-      ${6} | ${52}     | ${['map', 'Flow style', 'Oren']}
-      ${6} | ${57}     | ${['map', 'Flow style', 'Oren']}
+      line   | character | path
+      ${8}   | ${0}      | ${['map', 'Block style']}
+      ${8}   | ${19}     | ${['map', 'Block style']}
+      ${12}  | ${0}      | ${['map', 'Flow style']}
+      ${12}  | ${4}      | ${['map', 'Flow style']}
+      ${12}  | ${25}     | ${['map', 'Flow style', 'Clark']}
+      ${12}  | ${34}     | ${['map', 'Flow style', 'Clark']}
+      ${12}  | ${38}     | ${['map', 'Flow style', 'Ingy']}
+      ${12}  | ${51}     | ${['map', 'Flow style', 'Oren']}
+      ${12}  | ${52}     | ${['map', 'Flow style', 'Oren']}
+      ${12}  | ${57}     | ${['map', 'Flow style', 'Oren']}
+      ${43}  | ${0}      | ${['set', 'baseball players', 'Mark McGwire']}
+      ${46}  | ${10}     | ${['set', 'baseball teams']}
+      ${46}  | ${36}     | ${['set', 'baseball teams', 'Boston Red Sox']}
+      ${46}  | ${42}     | ${['set', 'baseball teams', 'Detroit Tigers']}
+      ${46}  | ${70}     | ${['set', 'baseball teams', 'New York Yankees']}
+      ${46}  | ${77}     | ${['set', 'baseball teams']}
+      ${50}  | ${0}      | ${['seq']}
+      ${50}  | ${4}      | ${['seq']}
+      ${55}  | ${0}      | ${['seq', 'Block style', 2]}
+      ${55}  | ${12}     | ${['seq', 'Block style', 2]}
+      ${61}  | ${3}      | ${['seq', 'Block style', 8]}
+      ${61}  | ${40}     | ${['seq', 'Block style', 8]}
+      ${62}  | ${3}      | ${['seq', 'Flow style']}
+      ${62}  | ${28}     | ${['seq', 'Flow style', 0]}
+      ${62}  | ${49}     | ${['seq', 'Flow style', 3]}
+      ${62}  | ${64}     | ${['seq', 'Flow style']}
+      ${63}  | ${29}     | ${['seq', 'Flow style', 4]}
+      ${63}  | ${31}     | ${['seq', 'Flow style', 5]}
+      ${63}  | ${42}     | ${['seq', 'Flow style', 6]}
+      ${63}  | ${50}     | ${['seq', 'Flow style', 7]}
+      ${64}  | ${29}     | ${['seq', 'Flow style']}
+      ${64}  | ${35}     | ${['seq', 'Flow style']}
+      ${66}  | ${0}      | ${[]}
+      ${138} | ${0}      | ${['null', '~']}
+      ${202} | ${12}     | ${['foobar']}
+      ${204} | ${7}      | ${['foobar', 1]}
+      ${228} | ${13}     | ${['cities', 'asia', 2]}
     `('should return proper json path for line $line and character $character', ({ line, character, path }) => {
       expect(getJsonPathForPosition(result, { line, character })).toEqual(path);
     });

--- a/src/__tests__/getJsonPathForPosition.spec.ts
+++ b/src/__tests__/getJsonPathForPosition.spec.ts
@@ -9,7 +9,27 @@ const simple = `hello: world
 address:
   street: 123`;
 
+const emptyValues = `host: example.com
+securityDefinitions: {}
+paths: {}
+parameters:
+ skip:
+    in: query
+    type: string
+    name: skip`;
+
 describe('getJsonPathForPosition', () => {
+  describe('emptyValues fixture', () => {
+    const result = parseWithPointers(emptyValues);
+
+    test.each`
+      line | character | path
+      ${2} | ${9}      | ${['paths']}
+    `('should return proper json path for line $line and character $character', ({ line, character, path }) => {
+      expect(getJsonPathForPosition(result, { line, character })).toEqual(path);
+    });
+  });
+
   describe('simple fixture', () => {
     const result = parseWithPointers(simple);
 
@@ -37,17 +57,22 @@ describe('getJsonPathForPosition', () => {
       ${12}  | ${0}      | ${['map', 'Flow style']}
       ${12}  | ${4}      | ${['map', 'Flow style']}
       ${12}  | ${25}     | ${['map', 'Flow style', 'Clark']}
-      ${12}  | ${34}     | ${['map', 'Flow style', 'Clark']}
+      ${12}  | ${33}     | ${['map', 'Flow style', 'Clark']}
       ${12}  | ${38}     | ${['map', 'Flow style', 'Ingy']}
       ${12}  | ${51}     | ${['map', 'Flow style', 'Oren']}
       ${12}  | ${52}     | ${['map', 'Flow style', 'Oren']}
       ${12}  | ${57}     | ${['map', 'Flow style', 'Oren']}
-      ${43}  | ${0}      | ${['set', 'baseball players', 'Mark McGwire']}
+      ${13}  | ${0}      | ${undefined}
+      ${19}  | ${0}      | ${['omap', 'Bestiary', 0, 'aardvark']}
+      ${19}  | ${10}     | ${['omap', 'Bestiary', 0, 'aardvark']}
+      ${19}  | ${32}     | ${['omap', 'Bestiary', 0, 'aardvark']}
+      ${42}  | ${0}      | ${['set', 'baseball players', 'Mark McGwire']}
+      ${43}  | ${0}      | ${['set', 'baseball players', 'Sammy Sosa']}
       ${46}  | ${10}     | ${['set', 'baseball teams']}
       ${46}  | ${36}     | ${['set', 'baseball teams', 'Boston Red Sox']}
       ${46}  | ${42}     | ${['set', 'baseball teams', 'Detroit Tigers']}
       ${46}  | ${70}     | ${['set', 'baseball teams', 'New York Yankees']}
-      ${46}  | ${77}     | ${['set', 'baseball teams']}
+      ${46}  | ${75}     | ${['set', 'baseball teams']}
       ${50}  | ${0}      | ${['seq']}
       ${50}  | ${4}      | ${['seq']}
       ${55}  | ${0}      | ${['seq', 'Block style', 2]}
@@ -56,19 +81,23 @@ describe('getJsonPathForPosition', () => {
       ${61}  | ${40}     | ${['seq', 'Block style', 8]}
       ${62}  | ${3}      | ${['seq', 'Flow style']}
       ${62}  | ${28}     | ${['seq', 'Flow style', 0]}
-      ${62}  | ${49}     | ${['seq', 'Flow style', 3]}
+      ${62}  | ${48}     | ${['seq', 'Flow style', 3]}
+      ${62}  | ${49}     | ${['seq', 'Flow style']}
       ${62}  | ${64}     | ${['seq', 'Flow style']}
       ${63}  | ${29}     | ${['seq', 'Flow style', 4]}
       ${63}  | ${31}     | ${['seq', 'Flow style', 5]}
       ${63}  | ${42}     | ${['seq', 'Flow style', 6]}
       ${63}  | ${50}     | ${['seq', 'Flow style', 7]}
-      ${64}  | ${29}     | ${['seq', 'Flow style']}
-      ${64}  | ${35}     | ${['seq', 'Flow style']}
-      ${66}  | ${0}      | ${[]}
+      ${66}  | ${0}      | ${undefined}
       ${138} | ${0}      | ${['null', '~']}
       ${202} | ${12}     | ${['foobar']}
       ${204} | ${7}      | ${['foobar', 1]}
+      ${216} | ${12}     | ${['austrian-cities', 3]}
+      ${220} | ${0}      | ${['cities', 'europe', 0]}
       ${228} | ${13}     | ${['cities', 'asia', 2]}
+      ${234} | ${0}      | ${['european-cities', 'germany']}
+      ${235} | ${0}      | ${['european-cities']}
+      ${236} | ${0}      | ${['european-cities', 'austria']}
     `('should return proper json path for line $line and character $character', ({ line, character, path }) => {
       expect(getJsonPathForPosition(result, { line, character })).toEqual(path);
     });

--- a/src/getJsonPathForPosition.ts
+++ b/src/getJsonPathForPosition.ts
@@ -146,7 +146,7 @@ function buildJsonPath(node: YAMLNode) {
           const index = (node as YAMLSequence).items.indexOf(prevNode);
           if (prevNode.kind === Kind.SCALAR) {
             path[0] = index;
-            // always better point to parent rather than nothing
+            // always better to point to parent node rather than nothing
           } else if (index !== -1) {
             path.unshift(index);
           }

--- a/src/parseWithPointers.ts
+++ b/src/parseWithPointers.ts
@@ -31,6 +31,8 @@ const walk = <T>(container: T, nodes: YAMLNode[], lineMap: number[]) => {
 
     const index = parseInt(i);
     const node = nodes[index];
+    if (node === null) continue;
+
     const key = node.key ? node.key.value : index;
 
     const mappings = get(node, 'mappings', get(node, 'value.mappings'));


### PR DESCRIPTION
This PR fixes a couple of minor issues in `getJsonPathForPosition` and makes the function more robust.
As you can see, a new fixture containing various syntax features has been included and this turned out to be a right call as a couple of issues and flaws have been exposed.
I addressed most of them and, in general, made a number of minor improvements here and there.

Incomprehensive list of changes:
- handle multi-line scalar nodes correctly. This is the most significant change and an actual bug fix since the path is not generated correctly when any line but first of the given node is provided. You can observe the incorrect behavior when you click on a non-first line of any multi-line string.
- more reasonable holes handling. A 'hole' is an offset that cannot be linked to any node. Whitespaces and line-breaks aren't represented in AST, so a node prepended/followed by whitespaces/line-break will have its offset shifted respectively. The former implementation worked fairly reliably in the majority of cases, but I tweaked it further. The new approach basically tries to find the closest scalar node placed on the given line if a hole is encountered. I guess there might still cases that could be handled slightly better, we'll know soon.
- return undefined rather than an empty array
- consistent treatment of edge characters (columns)
- inline nodes are supported

Moreover, I added a bunch of tests, so we can implement further changes with more confidence.

There is one unrelated change made to `parseWithPointers` - addressed TypeError, as typings are screwed up :(. For instance, `YAMLMapping['value']` isn't nullable, while it in fact is, but there are apparently even more broken types.

Open questions:
- [ ] is the current way of handling `ANCHOR_REF` nodes valid? At the moment, we treat such nodes as they were 'regular' nodes and ignore their referenced value.
I believe we won't need to change anything in this regard, but I still wanted to bring it up to the discussion, as it kind of slipped through the cracks last time and we had a `todo` comment in place.

