### PR TITLE
feat: dupe-keys

### DIFF
--- a/src/__tests__/lineForPosition.spec.ts
+++ b/src/__tests__/lineForPosition.spec.ts
@@ -7,6 +7,7 @@ describe('lineForPosition', () => {
     expect(lineForPosition(0, lines)).toEqual(0);
 
     expect(lineForPosition(12, lines)).toEqual(0);
+    expect(lineForPosition(13, lines)).toEqual(1);
     expect(lineForPosition(35, lines)).toEqual(2);
 
     // last line
@@ -47,7 +48,7 @@ describe('lineForPosition', () => {
     // first line
     expect(lineForPosition(0, lines)).toEqual(0);
     expect(lineForPosition(1, lines)).toEqual(0);
-    expect(lineForPosition(4, lines)).toEqual(0);
+    expect(lineForPosition(4, lines)).toEqual(1);
     expect(lineForPosition(5, lines)).toEqual(1);
     expect(lineForPosition(51, lines)).toEqual(2);
     expect(lineForPosition(255, lines)).toEqual(12);

--- a/src/__tests__/parseWithPointers.spec.ts
+++ b/src/__tests__/parseWithPointers.spec.ts
@@ -235,4 +235,69 @@ european-cities: &cities
       expect(() => JSON.stringify(result.data)).not.toThrow();
     });
   });
+
+  test('reports duplicated properties', () => {
+    expect(parseWithPointers('foo: 0\nfoo: 0\n', { ignoreDuplicateKeys: false })).toHaveProperty('diagnostics', [
+      {
+        code: 'YAMLException',
+        message: 'duplicate key',
+        range: {
+          start: {
+            line: 1,
+            character: 0,
+          },
+          end: {
+            line: 1,
+            character: 3,
+          },
+        },
+        severity: DiagnosticSeverity.Error,
+      },
+    ]);
+
+    expect(
+      parseWithPointers(
+        `baz:
+  duplicated: 2
+  baz: 3
+  duplicated: boo
+  duplicated: 
+    - yes
+    - unfortunately, I am a dupe.
+`,
+        { ignoreDuplicateKeys: false }
+      )
+    ).toHaveProperty('diagnostics', [
+      {
+        code: 'YAMLException',
+        message: 'duplicate key',
+        range: {
+          start: {
+            line: 3,
+            character: 2,
+          },
+          end: {
+            line: 3,
+            character: 12,
+          },
+        },
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        code: 'YAMLException',
+        message: 'duplicate key',
+        range: {
+          start: {
+            line: 4,
+            character: 2,
+          },
+          end: {
+            line: 4,
+            character: 12,
+          },
+        },
+        severity: DiagnosticSeverity.Error,
+      },
+    ]);
+  });
 });

--- a/src/lineForPosition.ts
+++ b/src/lineForPosition.ts
@@ -23,7 +23,7 @@ export const lineForPosition = (pos: number, lines: number[], start: number = 0,
   // if pos is between target and the next line's position, we're good!
   const nextLinePos = lines[Math.min(target + 1, lines.length)];
 
-  if (pos === lines[target]) {
+  if (pos === lines[target] - 1) {
     return target;
   }
 


### PR DESCRIPTION
as needed by https://github.com/stoplightio/spectral/issues/258 + a minor bugfix related to line boundaries that are obviously 1-based.
