### PR TITLE
fix: make ast.errors empty

### DIFF
--- a/src/parseWithPointers.ts
+++ b/src/parseWithPointers.ts
@@ -50,6 +50,10 @@ export const parseWithPointers = <T>(value: string, options?: IParseOptions): Ya
     parsed.diagnostics.sort((itemA, itemB) => itemA.range.start.line - itemB.range.start.line);
   }
 
+  if (Array.isArray(parsed.ast.errors)) {
+    parsed.ast.errors.length = 0;
+  }
+
   return parsed;
 };
 

--- a/src/parseWithPointers.ts
+++ b/src/parseWithPointers.ts
@@ -152,14 +152,16 @@ const dereferenceAnchor = (node: YAMLNode, anchorId: string): YAMLNode | YAMLNod
 
 // builds up the line map, for use by linesForPosition
 const computeLineMap = (input: string) => {
-  const lines = input.split(/\n/);
   const lineMap: number[] = [];
 
-  let sum = 0;
-  for (const line of lines) {
-    sum += line.length + 1;
-    lineMap.push(sum);
+  let i = 0;
+  for (; i < input.length; i++) {
+    if (input[i] === '\n') {
+      lineMap.push(i + 1);
+    }
   }
+
+  lineMap.push(i + 1);
 
   return lineMap;
 };


### PR DESCRIPTION
There is no reason to have ast.errors given we make use of our own `diagnostics`, which have `ast.errors` included and transformed (i.e. heavy buffer is striped)