### PR TITLE
fix(dereferencing): set null as the value of the property

### DIFF
--- a/src/__tests__/__snapshots__/parse.spec.ts.snap
+++ b/src/__tests__/__snapshots__/parse.spec.ts.snap
@@ -4,36 +4,36 @@ exports[`parse dereferencing anchor refs insane edge case 1`] = `
 Array [
   Array [
     Array [
-      undefined,
+      null,
       Object {
         "test": Array [
-          undefined,
+          null,
         ],
       },
       Object {
         "abc": Object {
           "a": null,
-          "c": undefined,
+          "c": null,
           "foo": 2,
-          "x": undefined,
+          "x": null,
         },
       },
     ],
     Object {
       "test": Array [
         Array [
-          undefined,
+          null,
           Object {
             "test": Array [
-              undefined,
+              null,
             ],
           },
           Object {
             "abc": Object {
               "a": null,
-              "c": undefined,
+              "c": null,
               "foo": 2,
-              "x": undefined,
+              "x": null,
             },
           },
         ],
@@ -43,27 +43,27 @@ Array [
       "abc": Object {
         "a": null,
         "c": Array [
-          undefined,
+          null,
           Object {
             "test": Array [
-              undefined,
+              null,
             ],
           },
           Object {
             "abc": Object {
               "a": null,
-              "c": undefined,
+              "c": null,
               "foo": 2,
-              "x": undefined,
+              "x": null,
             },
           },
         ],
         "foo": 2,
         "x": Object {
           "a": null,
-          "c": undefined,
+          "c": null,
           "foo": 2,
-          "x": undefined,
+          "x": null,
         },
       },
     },

--- a/src/__tests__/__snapshots__/parseWithPointers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/parseWithPointers.spec.ts.snap
@@ -4,36 +4,36 @@ exports[`yaml parser dereferencing anchor refs insane edge case 1`] = `
 Array [
   Array [
     Array [
-      undefined,
+      null,
       Object {
         "test": Array [
-          undefined,
+          null,
         ],
       },
       Object {
         "abc": Object {
           "a": null,
-          "c": undefined,
+          "c": null,
           "foo": 2,
-          "x": undefined,
+          "x": null,
         },
       },
     ],
     Object {
       "test": Array [
         Array [
-          undefined,
+          null,
           Object {
             "test": Array [
-              undefined,
+              null,
             ],
           },
           Object {
             "abc": Object {
               "a": null,
-              "c": undefined,
+              "c": null,
               "foo": 2,
-              "x": undefined,
+              "x": null,
             },
           },
         ],
@@ -43,27 +43,27 @@ Array [
       "abc": Object {
         "a": null,
         "c": Array [
-          undefined,
+          null,
           Object {
             "test": Array [
-              undefined,
+              null,
             ],
           },
           Object {
             "abc": Object {
               "a": null,
-              "c": undefined,
+              "c": null,
               "foo": 2,
-              "x": undefined,
+              "x": null,
             },
           },
         ],
         "foo": 2,
         "x": Object {
           "a": null,
-          "c": undefined,
+          "c": null,
           "foo": 2,
-          "x": undefined,
+          "x": null,
         },
       },
     },

--- a/src/__tests__/parse.spec.ts
+++ b/src/__tests__/parse.spec.ts
@@ -53,7 +53,7 @@ to save space`,
 european-cities:
   austria: *austrian-cities
 `);
-      expect(result).toEqual({
+      expect(result).toStrictEqual({
         'austrian-cities': ['Vienna', 'Graz', 'Linz', 'Salzburg'],
         'european-cities': {
           austria: ['Vienna', 'Graz', 'Linz', 'Salzburg'],
@@ -68,13 +68,13 @@ european-cities:
       name: *ref
 `);
 
-      expect(result).toEqual({
+      expect(result).toStrictEqual({
         definitions: {
           model: {
             foo: {
               name: {
                 foo: {
-                  name: undefined,
+                  name: null,
                 },
               },
             },
@@ -90,10 +90,10 @@ european-cities:
   - test:
     - *foo
 `);
-      expect(result).toEqual([
+      expect(result).toStrictEqual([
         [
           {
-            test: [[{ test: [undefined] }]],
+            test: [[{ test: [null] }]],
           },
         ],
       ]);
@@ -113,10 +113,11 @@ european-cities: &cities
     all: *cities
 `);
 
-      expect(result).toEqual({
+      expect(result).toStrictEqual({
         'austrian-cities': ['Vienna', 'Graz', 'Linz', 'Salzburg'],
         'european-cities': {
           all: {
+            all: null,
             austria: ['Vienna', 'Graz', 'Linz', 'Salzburg'],
           },
           austria: ['Vienna', 'Graz', 'Linz', 'Salzburg'],
@@ -134,10 +135,10 @@ european-cities: &cities
     - *foo
 `);
 
-      expect(result).toEqual({
+      expect(result).toStrictEqual({
         a: [
           {
-            b: [true, { c: [true, { c: undefined }, undefined] }, [{ b: [true, { c: undefined }, undefined] }]],
+            b: [true, { c: [true, { c: null }, null] }, [{ b: [true, { c: null }, null] }]],
           },
         ],
       });

--- a/src/__tests__/parseWithPointers.spec.ts
+++ b/src/__tests__/parseWithPointers.spec.ts
@@ -170,7 +170,7 @@ european-cities:
             foo: {
               name: {
                 foo: {
-                  name: undefined,
+                  name: null,
                 },
               },
             },
@@ -189,7 +189,7 @@ european-cities:
       expect(result.data).toEqual([
         [
           {
-            test: [[{ test: [undefined] }]],
+            test: [[{ test: [null] }]],
           },
         ],
       ]);
@@ -209,10 +209,11 @@ european-cities: &cities
     all: *cities
 `);
 
-      expect(result.data).toEqual({
+      expect(result.data).toStrictEqual({
         'austrian-cities': ['Vienna', 'Graz', 'Linz', 'Salzburg'],
         'european-cities': {
           all: {
+            all: null,
             austria: ['Vienna', 'Graz', 'Linz', 'Salzburg'],
           },
           austria: ['Vienna', 'Graz', 'Linz', 'Salzburg'],
@@ -230,10 +231,10 @@ european-cities: &cities
     - *foo
 `);
 
-      expect(result.data).toEqual({
+      expect(result.data).toStrictEqual({
         a: [
           {
-            b: [true, { c: [true, { c: undefined }, undefined] }, [{ b: [true, { c: undefined }, undefined] }]],
+            b: [true, { c: [true, { c: null }, null] }, [{ b: [true, { c: null }, null] }]],
           },
         ],
       });


### PR DESCRIPTION
A follow-up PR for https://github.com/stoplightio/yaml/pull/28
Null is more suitable here. `undefined` is a plain string scalar in case of YAML.