### PR TITLE
fix(safe-stringify): stringify falsy values and strings

### DIFF
--- a/src/__tests__/safeStringify.spec.ts
+++ b/src/__tests__/safeStringify.spec.ts
@@ -4,9 +4,16 @@ describe('safeStringify', () => {
   it('should work', () => {
     const val = { foo: true };
 
-    expect(safeStringify(val)).toEqual(`foo: true
-`);
-    expect(safeStringify('foo: true')).toEqual('foo: true');
+    expect(safeStringify(val)).toEqual('foo: true\n');
+  });
+
+  it('should stringify strings correctly', () => {
+    expect(safeStringify('foo: true')).toEqual("'foo: true'\n");
+    expect(safeStringify('')).toEqual("''\n");
+  });
+
+  it.each([0, null, false])('should stringify falsy value: %s', value => {
+    expect(safeStringify(value)).toEqual(`${value}\n`);
   });
 
   it('should respect lineWidth for multi-line strings', () => {

--- a/src/__tests__/safeStringify.spec.ts
+++ b/src/__tests__/safeStringify.spec.ts
@@ -7,9 +7,9 @@ describe('safeStringify', () => {
     expect(safeStringify(val)).toEqual('foo: true\n');
   });
 
-  it('should stringify strings correctly', () => {
-    expect(safeStringify('foo: true')).toEqual("'foo: true'\n");
-    expect(safeStringify('')).toEqual("''\n");
+  it('should not stringify strings twice', () => {
+    expect(safeStringify('foo: true')).toEqual('foo: true');
+    expect(safeStringify('')).toEqual('');
   });
 
   it.each([0, null, false])('should stringify falsy value: %s', value => {

--- a/src/safeStringify.ts
+++ b/src/safeStringify.ts
@@ -1,7 +1,5 @@
 import { DumpOptions, safeDump } from '@stoplight/yaml-ast-parser';
 
 export const safeStringify = (value: any, options?: DumpOptions): string => {
-  if (!value || typeof value === 'string') return value;
-
   return safeDump(value, options);
 };

--- a/src/safeStringify.ts
+++ b/src/safeStringify.ts
@@ -1,5 +1,4 @@
 import { DumpOptions, safeDump } from '@stoplight/yaml-ast-parser';
 
-export const safeStringify = (value: any, options?: DumpOptions): string => {
-  return safeDump(value, options);
-};
+export const safeStringify = (value: unknown, options?: DumpOptions): string =>
+  typeof value === 'string' ? value : safeDump(value, options);


### PR DESCRIPTION
Needed by https://github.com/stoplightio/json-schema-ref-parser/pull/1 (2 tests fail due to this issue)
The caveat is... we'd be inconsistent with https://github.com/stoplightio/json/blob/master/src/safeStringify.ts#L10 that implements a similar logic.
I know we do it to avoid stringifying twice, so - I'm happy to simply change that test in json-schema-ref-parser.
Would still love to keep that removal of falsy check.