### PR TITLE
fix: handle circular anchors with greater success

### DIFF
--- a/src/__tests__/__snapshots__/parseWithPointers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/parseWithPointers.spec.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`yaml parser dereferencing anchor refs insane edge case #2 1`] = `
+Object {
+  "a": Object {
+    "b": Object {
+      "c": Array [
+        Object {
+          "a": Object {
+            "b": Object {
+              "c": Array [
+                null,
+              ],
+            },
+            "d": Object {
+              "c": Array [
+                null,
+              ],
+            },
+          },
+        },
+      ],
+    },
+    "d": Object {
+      "c": Array [
+        null,
+      ],
+    },
+  },
+}
+`;
+
 exports[`yaml parser dereferencing anchor refs insane edge case 1`] = `
 Array [
   Array [

--- a/src/__tests__/parseWithPointers.spec.ts
+++ b/src/__tests__/parseWithPointers.spec.ts
@@ -266,7 +266,6 @@ a:
       - *ref_1
   d:
     *ref_2
-
 `);
       expect(result.data).toMatchSnapshot();
       expect(() => JSON.stringify(result.data)).not.toThrow();

--- a/src/__tests__/parseWithPointers.spec.ts
+++ b/src/__tests__/parseWithPointers.spec.ts
@@ -257,6 +257,20 @@ european-cities: &cities
 
       expect(() => JSON.stringify(result.data)).not.toThrow();
     });
+
+    test('insane edge case #2', () => {
+      const result = parseWithPointers(`&ref_1
+a:
+  b: &ref_2
+    c:
+      - *ref_1
+  d:
+    *ref_2
+
+`);
+      expect(result.data).toMatchSnapshot();
+      expect(() => JSON.stringify(result.data)).not.toThrow();
+    });
   });
 
   describe('duplicate keys', () => {

--- a/src/dereferenceAnchor.ts
+++ b/src/dereferenceAnchor.ts
@@ -1,0 +1,45 @@
+import { Kind, YAMLAnchorReference, YAMLMapping, YAMLNode } from './types';
+import { isObject } from './utils';
+
+export const dereferenceAnchor = (node: YAMLNode | null, anchorId: string): YAMLNode | null => {
+  if (!isObject(node)) return node;
+  if (node.kind === Kind.ANCHOR_REF && node.referencesAnchor === anchorId) return null;
+
+  switch (node.kind) {
+    case Kind.MAP:
+      return {
+        ...node,
+        mappings: node.mappings.map(mapping => dereferenceAnchor(mapping, anchorId) as YAMLMapping),
+      };
+    case Kind.SEQ:
+      return {
+        ...node,
+        items: node.items.map(item => dereferenceAnchor(item, anchorId)!),
+      };
+    case Kind.MAPPING:
+      return { ...node, value: dereferenceAnchor(node.value, anchorId) };
+    case Kind.SCALAR:
+      return node;
+    case Kind.ANCHOR_REF:
+      if (isObject(node.value) && isSelfReferencingAnchorRef(node)) {
+        return null;
+      }
+
+      return node;
+    default:
+      return node;
+  }
+};
+
+const isSelfReferencingAnchorRef = (anchorRef: YAMLAnchorReference) => {
+  const { referencesAnchor } = anchorRef;
+  let node: YAMLNode | undefined = anchorRef;
+  // tslint:disable-next-line:no-conditional-assignment
+  while ((node = node.parent)) {
+    if ('anchorId' in node && node.anchorId === referencesAnchor) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './buildJsonPath';
+export * from './dereferenceAnchor';
 export * from './getJsonPathForPosition';
 export * from './getLocationForJsonPath';
 export * from './lineForPosition';

--- a/src/parseWithPointers.ts
+++ b/src/parseWithPointers.ts
@@ -9,17 +9,9 @@ import {
 } from '@stoplight/yaml-ast-parser';
 import { buildJsonPath } from './buildJsonPath';
 import { SpecialMappingKeys } from './consts';
+import { dereferenceAnchor } from './dereferenceAnchor';
 import { lineForPosition } from './lineForPosition';
-import {
-  IParseOptions,
-  Kind,
-  ScalarType,
-  YAMLAnchorReference,
-  YAMLMapping,
-  YAMLNode,
-  YamlParserResult,
-  YAMLScalar,
-} from './types';
+import { IParseOptions, Kind, ScalarType, YAMLMapping, YAMLNode, YamlParserResult, YAMLScalar } from './types';
 import { isObject } from './utils';
 
 export const parseWithPointers = <T>(value: string, options?: IParseOptions): YamlParserResult<T | undefined> => {
@@ -136,49 +128,6 @@ export const walkAST = (
   }
 
   return node;
-};
-
-const isSelfReferencingAnchorRef = (anchorRef: YAMLAnchorReference) => {
-  const { referencesAnchor } = anchorRef;
-  let node: YAMLNode | undefined = anchorRef;
-  // tslint:disable-next-line:no-conditional-assignment
-  while ((node = node.parent)) {
-    if ('anchorId' in node && node.anchorId === referencesAnchor) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
-const dereferenceAnchor = (node: YAMLNode | null, anchorId: string): YAMLNode | null => {
-  if (!isObject(node)) return node;
-  if (node.kind === Kind.ANCHOR_REF && node.referencesAnchor === anchorId) return null;
-
-  switch (node.kind) {
-    case Kind.MAP:
-      return {
-        ...node,
-        mappings: node.mappings.map(mapping => dereferenceAnchor(mapping, anchorId) as YAMLMapping),
-      };
-    case Kind.SEQ:
-      return {
-        ...node,
-        items: node.items.map(item => dereferenceAnchor(item, anchorId)!),
-      };
-    case Kind.MAPPING:
-      return { ...node, value: dereferenceAnchor(node.value, anchorId) };
-    case Kind.SCALAR:
-      return node;
-    case Kind.ANCHOR_REF:
-      if (isObject(node.value) && isSelfReferencingAnchorRef(node)) {
-        return null;
-      }
-
-      return node;
-    default:
-      return node;
-  }
 };
 
 function getScalarValue(node: YAMLScalar): number | null | boolean | string | void {

--- a/src/parseWithPointers.ts
+++ b/src/parseWithPointers.ts
@@ -124,11 +124,11 @@ export const walkAST = (
       case Kind.SCALAR:
         return getScalarValue(node);
       case Kind.ANCHOR_REF: {
-        if (isObject(node.value) && isCircularAnchorRef(node)) {
+        if (isObject(node.value)) {
           node.value = dereferenceAnchor(node.value, node.referencesAnchor)!;
         }
 
-        return node.value && walkAST(node.value, options, lineMap, diagnostics);
+        return walkAST(node.value!, options, lineMap, diagnostics);
       }
       default:
         return null;
@@ -138,7 +138,7 @@ export const walkAST = (
   return node;
 };
 
-const isCircularAnchorRef = (anchorRef: YAMLAnchorReference) => {
+const isSelfReferencingAnchorRef = (anchorRef: YAMLAnchorReference) => {
   const { referencesAnchor } = anchorRef;
   let node: YAMLNode | undefined = anchorRef;
   // tslint:disable-next-line:no-conditional-assignment
@@ -171,7 +171,7 @@ const dereferenceAnchor = (node: YAMLNode | null, anchorId: string): YAMLNode | 
     case Kind.SCALAR:
       return node;
     case Kind.ANCHOR_REF:
-      if (isObject(node.value) && isCircularAnchorRef(node)) {
+      if (isObject(node.value) && isSelfReferencingAnchorRef(node)) {
         return null;
       }
 


### PR DESCRIPTION
Addresses one of the issue raised here https://github.com/stoplightio/platform-internal/issues/1070.
YAML Monaco worker thingy still needs to be fixed, but having a working `dereferenceAnchor` will be useful in fixing the error there.