### PR TITLE
fix: bump yaml-ast-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@stoplight/types": "^11.1.1",
-    "@stoplight/yaml-ast-parser": "0.0.44",
+    "@stoplight/yaml-ast-parser": "0.0.45",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/src/__tests__/safeStringify.spec.ts
+++ b/src/__tests__/safeStringify.spec.ts
@@ -66,4 +66,10 @@ b:
   foo: bar
 `);
   });
+
+  test('should stringify strings containing numbers with leading 0 (but are not octals) correctly', () => {
+    const obj = { value: '012345678' };
+
+    expect(safeStringify(obj, { noRefs: true })).toEqual(`value: '012345678'\n`);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,10 +1582,10 @@
   dependencies:
     "@types/json-schema" "^7.0.3"
 
-"@stoplight/yaml-ast-parser@0.0.44":
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.44.tgz#ed3c962564283e9983f7895a6effc3994286df5e"
-  integrity sha512-PdY8p2Ufgtorf4d2DbKMfknILMa8KwuyyMMR/2lgK1mLaU8F5PKWYc+h9hIzC+ar0bh7m9h2rINo32m7ADfVyA==
+"@stoplight/yaml-ast-parser@0.0.45":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.45.tgz#672c0a1511d581843be5a9c55899ca95a30dcadb"
+  integrity sha512-0MTEvgp3XMdeMUSTCGiNECuC+YlLbzytDEIOJVDHrrmzVZpIR3gGnHI6mmPI4P7saPxUiHxFF2uuoTuCNlKjrw==
 
 "@storybook/addon-actions@4.0.11":
   version "4.0.11"


### PR DESCRIPTION
Bumps yaml-ast-parser that fixes stringifying string containing numbers with leading 0 (not octals)