### PR TITLE
fix: more sane errors for unclosed flow collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@stoplight/ordered-object-literal": "^1.0.1",
-    "@stoplight/types": "^11.9.0",
+    "@stoplight/types": "^12.0.0",
     "@stoplight/yaml-ast-parser": "0.0.48",
-    "tslib": "^1.12.0"
+    "tslib": "^2.2.0"
   },
   "devDependencies": {
     "@stoplight/scripts": "3.1.0",

--- a/src/__tests__/parseWithPointers.spec.ts
+++ b/src/__tests__/parseWithPointers.spec.ts
@@ -34,7 +34,7 @@ describe('yaml parser', () => {
     expect(result.data).toEqual(HugeJSON);
   });
 
-  it('parses string according to YAML 1.2 spec', () => {
+  test('parses string according to YAML 1.2 spec', () => {
     const { data } = parseWithPointers(spectral481);
     expect(data).toHaveProperty(
       'components.schemas.RandomRequest.properties.implicit_string_date.example',
@@ -131,6 +131,88 @@ prop2: true
             end: {
               character: 7,
               line: 3,
+            },
+          },
+        },
+      ]);
+    });
+
+    test('unclosed flow sequence', () => {
+      const result = parseWithPointers(`austrian-cities: [
+- Vienna  
+- Graz
+- Linz
+- Salzburg
+`);
+      expect(result.diagnostics).toEqual([
+        {
+          severity: DiagnosticSeverity.Error,
+          message: 'invalid mixed usage of block and flow styles',
+          code: 'YAMLException',
+          range: {
+            start: {
+              character: 0,
+              line: 1,
+            },
+            end: {
+              character: 0,
+              line: 5,
+            },
+          },
+        },
+        {
+          severity: DiagnosticSeverity.Error,
+          message: 'unexpected end of the stream within a flow collection',
+          code: 'YAMLException',
+          range: {
+            start: {
+              character: 0,
+              line: 5,
+            },
+            end: {
+              character: 0,
+              line: 5,
+            },
+          },
+        },
+      ]);
+    });
+
+    test('unclosed flow mapping', () => {
+      const result = parseWithPointers(`austrian-cities: {
+- Vienna  
+- Graz
+- Linz
+- Salzburg
+`);
+      expect(result.diagnostics).toEqual([
+        {
+          severity: DiagnosticSeverity.Error,
+          message: 'invalid mixed usage of block and flow styles',
+          code: 'YAMLException',
+          range: {
+            start: {
+              character: 0,
+              line: 1,
+            },
+            end: {
+              character: 0,
+              line: 5,
+            },
+          },
+        },
+        {
+          severity: DiagnosticSeverity.Error,
+          message: 'unexpected end of the stream within a flow collection',
+          code: 'YAMLException',
+          range: {
+            start: {
+              character: 0,
+              line: 5,
+            },
+            end: {
+              character: 0,
+              line: 5,
             },
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,10 +1580,10 @@
     typedoc "0.13.x"
     typescript-plugin-styled-components "1.0.x"
 
-"@stoplight/types@^11.9.0":
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.9.0.tgz#ced7de2dd53439d2409a3cb390bf7d5b76382ac6"
-  integrity sha512-4bzPpWZobt0e+d0OtALCJyl1HGzKo6ur21qxnId9dTl8v3yeD+5HJKZ2h1mv7e94debH5QDtimMU80V6jbXM8Q==
+"@stoplight/types@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-12.0.0.tgz#3fc68ffa954e7c0a0e6261a982d5c0cb52d5d969"
+  integrity sha512-BbL0MIbcCwrU4RidcVyMKnRwACnhr7WAEgPH8d6rwhg/j2DegdLadnXCnq8UJXUWW9Apbntgvic3yVGvLtVmxA==
   dependencies:
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
@@ -12637,10 +12637,15 @@ tslib@1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslib@^1.12.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.12.0.tgz#d1fc9cacd06a1456c62f2902b361573e83d66473"
   integrity sha512-5rxCQkP0kytf4H1T4xz1imjxaUUPMvc5aWp0rJ/VMIN7ClRiH1FwFvBt8wOeMasp/epeUnmSW6CixSIePtiLqA==
+
+tslib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tslint-config-prettier@1.15.x:
   version "1.15.0"


### PR DESCRIPTION
For https://github.com/stoplightio/platform-internal/issues/6014
We could potentially address this in `yaml-ast-parser`, but IMHO what the parser does is correct. The parser is not to be blamed for trying to accumulate all errors.

The alternative approach I considered was adding some condition here https://github.com/stoplightio/yaml-ast-parser/blob/master/src/loader.ts#L854.
I was thinking of something as follows: if, say, comma is missed 5 times, we would just naively assume the flow collection might be possibly never closed correctly and just stop collecting these errors until the loading is able to recover.
However as said above, the parser does something incorrectly, so we can just filter them out here.

